### PR TITLE
Add WithExtraHTTP1 method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/onion_service_datadir

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"context"
+	"log"
+	"net"
+	"os"
+	"time"
+
+	"google.golang.org/grpc"
+	pb "google.golang.org/grpc/examples/helloworld/helloworld"
+
+	"golang.org/x/net/proxy"
+)
+
+const (
+	defaultAddress = "localhost:8080"
+)
+
+func main() {
+	// Set up a connection to the server.
+	address := defaultAddress
+	if len(os.Args) > 1 {
+		address = os.Args[1]
+	}
+
+	dialer, err := proxy.SOCKS5("tcp", "127.0.0.1:9150", nil, nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	conn, err := grpc.Dial(address, grpc.WithInsecure(), grpc.WithTimeout(15*time.Second), grpc.WithContextDialer(func(ctx context.Context, addr string) (net.Conn, error) {
+		return dialer.Dial("tcp", addr)
+	}))
+
+	if err != nil {
+		log.Fatalf("did not connect: %v", err)
+	}
+	defer conn.Close()
+	c := pb.NewGreeterClient(conn)
+
+	// Contact the server and print out its response.
+	name := "world"
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	r, err := c.SayHello(ctx, &pb.HelloRequest{Name: name})
+	if err != nil {
+		log.Fatalf("could not greet: %v", err)
+	}
+	log.Println(r.GetMessage())
+}

--- a/go.sum
+++ b/go.sum
@@ -115,6 +115,9 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/thinkgos/go-socks5 v0.2.2 h1:wZAbtzFes15jVdCw2iOKOzexTRHWDVOYWldBy2u2/PQ=
+github.com/thinkgos/go-socks5 v0.2.2/go.mod h1:5iine8bnDUUMdWZrCDIzUn9C2+GCC79LYxUrel1esAU=
 github.com/ugorji/go v1.1.7 h1:/68gy2h+1mWMrwZFeD1kQialdSzAb432dtpeJ42ovdo=
 github.com/ugorji/go v1.1.7/go.mod h1:kZn38zHttfInRq0xu/PH0az30d+z6vm202qpg1oXVMw=
 github.com/ugorji/go/codec v1.1.7 h1:2SvQaVZ1ouYrrKKwoSk2pzd4A9evlKJb9oTL+OaLUSs=
@@ -154,6 +157,7 @@ golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190923162816-aa69164e4478/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20200707034311-ab3426394381/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20210119194325-5f4716e94777 h1:003p0dJM77cxMSyCPFphvZf/Y5/NXf5fzg6ufd1/Oew=
@@ -241,6 +245,7 @@ gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.1-2019.2.3 h1:3JgtbtFHMiCmsznwGVTUWbgGov+pVqnlf1dEJTNAXeM=

--- a/pkg/mux/insecure.go
+++ b/pkg/mux/insecure.go
@@ -3,6 +3,7 @@ package mux
 import (
 	"net"
 
+	"github.com/soheilhy/cmux"
 	"google.golang.org/grpc"
 )
 
@@ -19,5 +20,6 @@ func NewMuxWithInsecure(grpcServer *grpc.Server, opts InsecureOptions) (*Mux, er
 		return nil, err
 	}
 
-	return &Mux{Listener: lis, GrpcServer: grpcServer}, nil
+	mux := cmux.New(lis)
+	return &Mux{mux: mux, Listener: lis, GrpcServer: grpcServer}, nil
 }

--- a/pkg/mux/mux.go
+++ b/pkg/mux/mux.go
@@ -10,22 +10,31 @@ import (
 	"github.com/cretz/bine/tor"
 	"github.com/improbable-eng/grpc-web/go/grpcweb"
 	"github.com/soheilhy/cmux"
+
 	"google.golang.org/grpc"
 )
 
 // Mux holds a net.Listener, a *grpc.Server and if onion service a *tor.Tor client
 type Mux struct {
+	mux        cmux.CMux
 	Listener   net.Listener
 	GrpcServer *grpc.Server
 
 	torClient *tor.Tor
+
+	extraServers []*HTTPServer
+}
+
+// HTTPServer holds a net.Listener and an http.Handler
+type HTTPServer struct {
+	Listener net.Listener
+	Handler  http.Handler
 }
 
 // Serve starts multiplexing gRPC and gRPC Web on the same port. Serve blocks and perhaps should be invoked concurrently within a go routine.
 func (m *Mux) Serve() error {
-	mux := cmux.New(m.Listener)
-	grpcL := mux.MatchWithWriters(cmux.HTTP2MatchHeaderFieldPrefixSendSettings("content-type", "application/grpc"))
-	httpL := mux.Match(cmux.HTTP1Fast())
+	grpcL := m.mux.MatchWithWriters(cmux.HTTP2MatchHeaderFieldPrefixSendSettings("content-type", "application/grpc"))
+	httpL := m.mux.Match(cmux.HTTP1Fast())
 
 	grpcWebServer := grpcweb.WrapServer(
 		m.GrpcServer,
@@ -37,10 +46,44 @@ func (m *Mux) Serve() error {
 	go http.Serve(httpL, http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
 		if isValidRequest(req) {
 			grpcWebServer.ServeHTTP(resp, req)
+		} else {
+			http.NotFound(resp, req)
 		}
 	}))
 
-	return mux.Serve()
+	if len(m.extraServers) > 0 {
+		for _, s := range m.extraServers {
+			go http.Serve(s.Listener, s.Handler)
+		}
+	}
+
+	return m.mux.Serve()
+}
+
+// WithExtraHTTP1 adds to the Mux an additional given HTTP1 handler and optional content-type.
+// if contentTypes is nil or empty array, any HTTP1 request will be matched
+// any of the contentTypes sourced MUST be different than `application/grpc-web-text` and `application/grpc-web`
+// because it will have matched before in the grpc-web server
+func (m *Mux) WithExtraHTTP1(handler http.Handler, contentTypes []string) {
+	if contentTypes == nil || len(contentTypes) == 0 {
+		lis := m.mux.Match(cmux.HTTP1())
+
+		m.extraServers = append(m.extraServers, &HTTPServer{
+			Listener: lis,
+			Handler:  handler,
+		})
+		return
+	}
+
+	for _, ct := range contentTypes {
+		lis := m.mux.Match(cmux.HTTP1HeaderFieldPrefix("content-type", ct))
+
+		m.extraServers = append(m.extraServers, &HTTPServer{
+			Listener: lis,
+			Handler:  handler,
+		})
+	}
+
 }
 
 // Close closes the TCP listener connection and in case of onion service it will also halt the tor client.

--- a/pkg/mux/mux_test.go
+++ b/pkg/mux/mux_test.go
@@ -2,6 +2,7 @@ package mux_test
 
 import (
 	"log"
+	"net/http"
 
 	"github.com/tiero/grpc-web-mux/pkg/mux"
 	"google.golang.org/grpc"
@@ -65,4 +66,30 @@ func ExampleNewMuxWithOnion() {
 
 	defer onionMux.Close()
 	onionMux.Serve()
+}
+
+func ExampleWithExtraHTTP1() {
+
+	myGrpcServer := grpc.NewServer()
+
+	insecureMux, err := mux.NewMuxWithInsecure(
+		myGrpcServer,
+		mux.InsecureOptions{Address: ":8080"},
+	)
+	if err != nil {
+		log.Panic(err)
+	}
+
+	insecureMux.WithExtraHTTP1(
+		http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+			rw.Write([]byte("Hello Insecure!"))
+		}),
+		nil,
+	)
+
+	log.Printf("Serving mux at %s\n", insecureMux.Listener.Addr().String())
+
+	defer insecureMux.Close()
+	insecureMux.Serve()
+
 }

--- a/pkg/mux/onion.go
+++ b/pkg/mux/onion.go
@@ -9,6 +9,7 @@ import (
 	"github.com/cretz/bine/control"
 	"github.com/cretz/bine/tor"
 	"github.com/ipsn/go-libtor"
+	"github.com/soheilhy/cmux"
 	"google.golang.org/grpc"
 )
 
@@ -63,7 +64,9 @@ func NewMuxWithOnion(grpcServer *grpc.Server, opts OnionOptions) (*Mux, error) {
 		return nil, fmt.Errorf("Failed to create onion service: %v", err)
 	}
 
+	mux := cmux.New(onion)
 	return &Mux{
+		mux:        mux,
 		Listener:   onion,
 		GrpcServer: grpcServer,
 		torClient:  torClient,

--- a/pkg/mux/tls.go
+++ b/pkg/mux/tls.go
@@ -4,7 +4,7 @@ import (
 	"crypto/tls"
 
 	"github.com/caddyserver/certmagic"
-	"golang.org/x/net/http2"
+	"github.com/soheilhy/cmux"
 	"google.golang.org/grpc"
 )
 
@@ -27,12 +27,13 @@ func NewMuxWithTLS(grpcServer *grpc.Server, opts TLSOptions) (*Mux, error) {
 
 	const requiredCipher = tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
 	tlsConfig.CipherSuites = []uint16{requiredCipher}
-	tlsConfig.NextProtos = []string{"http/1.1", http2.NextProtoTLS, "h2-14"} // h2-14 is just for compatibility. will be eventually removed.
+	tlsConfig.NextProtos = []string{"http/1.1", "h2", "h2-14"} // h2-14 is just for compatibility. will be eventually removed.
 
 	lis, err := tls.Listen("tcp", opts.Address, tlsConfig)
 	if err != nil {
 		return nil, err
 	}
 
-	return &Mux{Listener: lis, GrpcServer: grpcServer}, nil
+	mux := cmux.New(lis)
+	return &Mux{mux: mux, Listener: lis, GrpcServer: grpcServer}, nil
 }


### PR DESCRIPTION
This commit add `WithExtraHTTP1` method on `Mux` type which adds to the Mux an additional given HTTP1 handler and optional content-type. If contentTypes is nil or empty array, any HTTP1 request will be matched
any of the contentTypes sourced MUST be different than `application/grpc-web-text` and `application/grpc-web` because it will have matched before in the grpc-web server﻿
